### PR TITLE
feat!: use GA release of the Fabric Provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,18 @@
+# Local .terraform directories
+**/.terraform/*
+**/.external_modules/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Ignore lock files
+*.lock.hcl
+*.lock.info
+
+# Ignore transient lock info files created by terraform apply
+.terraform.tfstate.lock.info
+
+# Crash log files
+crash.log
+crash.*.log

--- a/Microsoft Fabric Infrastucture Deployment/fabric-infra/fabric-infra-environments/development.tfvars
+++ b/Microsoft Fabric Infrastucture Deployment/fabric-infra/fabric-infra-environments/development.tfvars
@@ -8,7 +8,7 @@ fabric_workspaces = {
     description  = "Dev workspace"
     roles = [
       {
-        principal_id   =  ""  #security groups object id
+        principal_id   = "" #security groups object id
         principal_type = "Group"
         role           = "Contributor"
       },
@@ -46,7 +46,7 @@ fabric_workspaces = {
     description  = ""
     roles = [
       {
-        principal_id   =  """"
+        principal_id   = ""
         principal_type = "Group"
         role           = "Contributor"
       },
@@ -76,7 +76,7 @@ fabric_workspaces = {
     description  = ""
     roles = [
       {
-        principal_id   =  """"
+        principal_id   = ""
         principal_type = "Group"
         role           = "Contributor"
       },
@@ -88,6 +88,7 @@ fabric_workspaces = {
 
       {
         principal_id   = ""
+        principal_type = "Group"
         role           = "Viewer"
       }
     ]
@@ -104,7 +105,7 @@ fabric_workspaces = {
     description  = ""
     roles = [
       {
-        principal_id   =  ""
+        principal_id   = ""
         principal_type = "Group"
         role           = "Contributor"
       },
@@ -134,7 +135,7 @@ fabric_workspaces = {
     description  = ""
     roles = [
       {
-        principal_id   =  ""
+        principal_id   = ""
         principal_type = "Group"
         role           = "Contributor"
       },
@@ -175,3 +176,4 @@ max_node_count                      = 9
 dynamic_executor_allocation_enabled = true
 min_executors                       = 1
 max_executors                       = 5
+capacity_name                       = ""

--- a/Microsoft Fabric Infrastucture Deployment/fabric-infra/fabric-infra-environments/production.tfvars
+++ b/Microsoft Fabric Infrastucture Deployment/fabric-infra/fabric-infra-environments/production.tfvars
@@ -8,7 +8,7 @@ fabric_workspaces = {
     description  = "Dev workspace"
     roles = [
       {
-        principal_id   =  ""  #security groups object id
+        principal_id   = "" #security groups object id
         principal_type = "Group"
         role           = "Contributor"
       },
@@ -46,7 +46,7 @@ fabric_workspaces = {
     description  = ""
     roles = [
       {
-        principal_id   =  """"
+        principal_id   = ""
         principal_type = "Group"
         role           = "Contributor"
       },
@@ -76,7 +76,7 @@ fabric_workspaces = {
     description  = ""
     roles = [
       {
-        principal_id   =  """"
+        principal_id   = ""
         principal_type = "Group"
         role           = "Contributor"
       },
@@ -88,6 +88,7 @@ fabric_workspaces = {
 
       {
         principal_id   = ""
+        principal_type = "Group"
         role           = "Viewer"
       }
     ]
@@ -104,7 +105,7 @@ fabric_workspaces = {
     description  = ""
     roles = [
       {
-        principal_id   =  ""
+        principal_id   = ""
         principal_type = "Group"
         role           = "Contributor"
       },
@@ -134,7 +135,7 @@ fabric_workspaces = {
     description  = ""
     roles = [
       {
-        principal_id   =  ""
+        principal_id   = ""
         principal_type = "Group"
         role           = "Contributor"
       },
@@ -175,3 +176,4 @@ max_node_count                      = 9
 dynamic_executor_allocation_enabled = true
 min_executors                       = 1
 max_executors                       = 5
+capacity_name                       = ""

--- a/Microsoft Fabric Infrastucture Deployment/fabric-infra/fabric-infra-environments/test.tfvars
+++ b/Microsoft Fabric Infrastucture Deployment/fabric-infra/fabric-infra-environments/test.tfvars
@@ -8,7 +8,7 @@ fabric_workspaces = {
     description  = "Dev workspace"
     roles = [
       {
-        principal_id   =  ""  #security groups object id
+        principal_id   = "" #security groups object id
         principal_type = "Group"
         role           = "Contributor"
       },
@@ -46,7 +46,7 @@ fabric_workspaces = {
     description  = ""
     roles = [
       {
-        principal_id   =  """"
+        principal_id   = ""
         principal_type = "Group"
         role           = "Contributor"
       },
@@ -76,7 +76,7 @@ fabric_workspaces = {
     description  = ""
     roles = [
       {
-        principal_id   =  """"
+        principal_id   = ""
         principal_type = "Group"
         role           = "Contributor"
       },
@@ -88,6 +88,7 @@ fabric_workspaces = {
 
       {
         principal_id   = ""
+        principal_type = "Group"
         role           = "Viewer"
       }
     ]
@@ -104,7 +105,7 @@ fabric_workspaces = {
     description  = ""
     roles = [
       {
-        principal_id   =  ""
+        principal_id   = ""
         principal_type = "Group"
         role           = "Contributor"
       },
@@ -134,7 +135,7 @@ fabric_workspaces = {
     description  = ""
     roles = [
       {
-        principal_id   =  ""
+        principal_id   = ""
         principal_type = "Group"
         role           = "Contributor"
       },
@@ -175,3 +176,4 @@ max_node_count                      = 9
 dynamic_executor_allocation_enabled = true
 min_executors                       = 1
 max_executors                       = 5
+capacity_name                       = ""

--- a/Microsoft Fabric Infrastucture Deployment/fabric-infra/modules/Workspace-role-assignment.tf
+++ b/Microsoft Fabric Infrastucture Deployment/fabric-infra/modules/Workspace-role-assignment.tf
@@ -3,10 +3,12 @@ resource "fabric_workspace_role_assignment" "fabric_workspace_role_assignment" {
   count = length(flatten([for workspace_key, workspace in var.fabric_workspaces :
     [for role in workspace.roles :
       {
-        workspace_id   = fabric_workspace.fabric_workspace[workspace_key].id
-        principal_id   = role.principal_id
-        principal_type = role.principal_type
-        role           = role.role
+        workspace_id = fabric_workspace.fabric_workspace[workspace_key].id
+        principal = {
+          id   = role.principal_id
+          type = role.principal_type
+        }
+        role = role.role
       }
     ]
   ]))
@@ -17,12 +19,11 @@ resource "fabric_workspace_role_assignment" "fabric_workspace_role_assignment" {
     ]
   ])[count.index]
 
-  principal_id = flatten([for workspace_key, workspace in var.fabric_workspaces :
-    [for role in workspace.roles : role.principal_id]
-  ])[count.index]
-
-  principal_type = flatten([for workspace_key, workspace in var.fabric_workspaces :
-    [for role in workspace.roles : role.principal_type]
+  principal = flatten([for workspace_key, workspace in var.fabric_workspaces :
+    [for role in workspace.roles : {
+      id   = role.principal_id
+      type = role.principal_type
+    }]
   ])[count.index]
 
   role = flatten([for workspace_key, workspace in var.fabric_workspaces :

--- a/Microsoft Fabric Infrastucture Deployment/fabric-infra/modules/Workspace.tf
+++ b/Microsoft Fabric Infrastucture Deployment/fabric-infra/modules/Workspace.tf
@@ -1,6 +1,6 @@
 # Workspace with Capacity and Identity
 data "fabric_capacity" "fabric_capacity" {
-  display_name = ""
+  display_name = var.capacity_name
 }
 
 

--- a/Microsoft Fabric Infrastucture Deployment/fabric-infra/modules/provider.tf
+++ b/Microsoft Fabric Infrastucture Deployment/fabric-infra/modules/provider.tf
@@ -2,25 +2,25 @@ terraform {
   required_version = ">= 1.8, < 2.0"
   required_providers {
     azurerm = {
-      source = "hashicorp/azurerm"
-      #  version = ">=3.0.0"
-      version = "4.14.0"
+      source  = "hashicorp/azurerm"
+      version = "4.29.0"
     }
     fabric = {
       source  = "microsoft/fabric"
-      version = "0.1.0-beta.8"
+      version = "1.1.0"
     }
   }
-  backend "azurerm" { ###### Configure the below values in the devops variable group to generate state file in Azure Storage Account
-    resource_group_name  = "$(backendAzureRmResourceGroupName)"
-    storage_account_name = "$(backendAzureRmStorageAccountName)"
-    container_name       = "$(backendAzureRmContainerName)"
-    key                  = "$(backendAzureRmKey)"
-  }
+  # backend "azurerm" { ###### Configure the below values in the devops variable group to generate state file in Azure Storage Account
+  #   resource_group_name  = "$(backendAzureRmResourceGroupName)"
+  #   storage_account_name = "$(backendAzureRmStorageAccountName)"
+  #   container_name       = "$(backendAzureRmContainerName)"
+  #   key                  = "$(backendAzureRmKey)"
+  # }
 }
 
 #Configure the Microsoft Fabric Terraform Provider
 provider "fabric" {
   # Configuration options
+  preview = true # Spark Custom Pool and Spark Workspace Settings are in preview
 }
 

--- a/Microsoft Fabric Infrastucture Deployment/fabric-infra/modules/provider.tf
+++ b/Microsoft Fabric Infrastucture Deployment/fabric-infra/modules/provider.tf
@@ -10,12 +10,13 @@ terraform {
       version = "1.1.0"
     }
   }
-  # backend "azurerm" { ###### Configure the below values in the devops variable group to generate state file in Azure Storage Account
-  #   resource_group_name  = "$(backendAzureRmResourceGroupName)"
-  #   storage_account_name = "$(backendAzureRmStorageAccountName)"
-  #   container_name       = "$(backendAzureRmContainerName)"
-  #   key                  = "$(backendAzureRmKey)"
-  # }
+  
+  backend "azurerm" { ###### Configure the below values in the devops variable group to generate state file in Azure Storage Account
+    resource_group_name  = "$(backendAzureRmResourceGroupName)"
+    storage_account_name = "$(backendAzureRmStorageAccountName)"
+    container_name       = "$(backendAzureRmContainerName)"
+    key                  = "$(backendAzureRmKey)"
+  }
 }
 
 #Configure the Microsoft Fabric Terraform Provider

--- a/Microsoft Fabric Infrastucture Deployment/fabric-infra/modules/spark-custom-pool.tf
+++ b/Microsoft Fabric Infrastucture Deployment/fabric-infra/modules/spark-custom-pool.tf
@@ -2,7 +2,9 @@
 
 
 resource "fabric_spark_custom_pool" "spark_pool" {
-  workspace_id = "" ##Workspace ID 
+  for_each = fabric_workspace.fabric_workspace
+
+  workspace_id = each.value.id 
   name         = var.spark_pool_name
   node_family  = var.node_family
   node_size    = var.node_size

--- a/Microsoft Fabric Infrastucture Deployment/fabric-infra/modules/variables.tf
+++ b/Microsoft Fabric Infrastucture Deployment/fabric-infra/modules/variables.tf
@@ -69,3 +69,8 @@ variable "max_executors" {
   type        = number
 }
 
+variable "capacity_name" {
+  description = "Name of the Fabric capacity"
+  type        = string
+}
+

--- a/Microsoft Fabric Infrastucture Deployment/fabric-infra/pipelines/azure-common-vars.yml
+++ b/Microsoft Fabric Infrastucture Deployment/fabric-infra/pipelines/azure-common-vars.yml
@@ -1,14 +1,14 @@
 variables:
-  
+
   # Terraform Configuration Variables
   - name: terraformVersion
-    value: '1.10.2'
+    value: '1.12.0'
 
   # Backend Configuration
   - name: backendServiceConnection
     value: '' # Azure Service Connection
 
-  - name: environmentServiceNameAzureRM      # Azure Service Connection
+  - name: environmentServiceNameAzureRM # Azure Service Connection
     value: ''
 
   - name: environmentGroupDevelopment
@@ -16,7 +16,7 @@ variables:
 
   - name: environmentGroupTest
     value: ''
-  
+
   - name: variableGroupDevelopment
     value: ''
 


### PR DESCRIPTION
- Fabric Terraform Provider is already GA and contains breaking change for "Workspace Role Assignment" - this PR address this change.
- Added `capacity_name` variable for easier use
- Minor linting